### PR TITLE
Simplify Pyodide demo with lightweight draw.io parser

### DIFF
--- a/pyodide-react/app.tsx
+++ b/pyodide-react/app.tsx
@@ -3,15 +3,9 @@ import { createRoot } from 'react-dom/client';
 
 const App = () => {
   // File contents stored in state
-  const [drawioContent, setDrawioContent] = useState(localStorage.getItem('drawioFileContent') || '');
-  const [csvContent, setCsvContent] = useState(localStorage.getItem('csvFileContent') || '');
-  const [ontologyIris, setOntologyIris] = useState(localStorage.getItem('ontologyIris') || 
-`rico: https://www.ica.org/standards/RiC/ontology#
-data: https://data.archives.gov.on.test.gbad.ca/
-auth: https://data.archives.gov.on.test.gbad.ca/Schema/Authority/
-add: https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/
-maps: https://data.archives.gov.on.test.gbad.ca/Schema/Mapping#
-rdfs: http://www.w3.org/2000/01/rdf-schema#`);
+  const [drawioContent, setDrawioContent] = useState(
+    localStorage.getItem('drawioFileContent') || ''
+  );
 
   const [savedMessage, setSavedMessage] = useState('');
   const [output, setOutput] = useState('');
@@ -22,10 +16,8 @@ rdfs: http://www.w3.org/2000/01/rdf-schema#`);
 
   // Show messages if files were already loaded from previous session
   useEffect(() => {
-    if (drawioContent) setSavedMessage('Draw.io file already loaded from previous session.');
-    if (csvContent) setSavedMessage(prev => prev 
-      ? prev + ' CSV file already loaded from previous session.'
-      : 'CSV file already loaded from previous session.');
+    if (drawioContent)
+      setSavedMessage('Draw.io file already loaded from previous session.');
   }, []);
 
   // Load Pyodide once
@@ -38,10 +30,7 @@ rdfs: http://www.w3.org/2000/01/rdf-schema#`);
         });
         await pyodide.current.loadPackage(['micropip']);
         const micropip = pyodide.current.pyimport('micropip');
-        await micropip.install('pandas');
         await micropip.install('rdflib');
-        await micropip.install('requests');
-        await micropip.install('lxml');
         setIsLoading(false);
       } catch (e) {
         setError('Failed to load Pyodide.');
@@ -53,8 +42,8 @@ rdfs: http://www.w3.org/2000/01/rdf-schema#`);
 
   // Handle conversion
   const handleConvert = async () => {
-    if (!drawioContent || !csvContent || !pyodide.current) {
-      setError('Please upload both a Draw.io and a CSV file.');
+    if (!drawioContent || !pyodide.current) {
+      setError('Please upload a Draw.io file.');
       return;
     }
 
@@ -64,59 +53,22 @@ rdfs: http://www.w3.org/2000/01/rdf-schema#`);
 
     try {
       // Load Python scripts
-      const drawIOParserPy = await (await fetch('https://raw.githubusercontent.com/gbad-project/records_in_contexts_draw_io_parser/refs/heads/review/feat/pyodide-converter/pyodide-react/draw_io_parser.py')).text();
-      const mapSchemaPy = await (await fetch('https://raw.githubusercontent.com/gbad-project/records_in_contexts_draw_io_parser/refs/heads/review/feat/pyodide-converter/pyodide-react/map_schema.py')).text();
-      const preprocessorsPy = await (await fetch('https://raw.githubusercontent.com/gbad-project/records_in_contexts_draw_io_parser/refs/heads/review/feat/pyodide-converter/gbad/converter/preprocessors.py')).text();
+      const parserPy = await (
+        await fetch('./draw_io_parser_simple.py')
+      ).text();
 
-      pyodide.current.FS.writeFile('/draw_io_parser.py', drawIOParserPy);
-      pyodide.current.FS.writeFile('/map_schema.py', mapSchemaPy);
-
-      // Write user files
+      pyodide.current.FS.writeFile('/draw_io_parser_simple.py', parserPy);
       pyodide.current.FS.writeFile('/user.drawio', drawioContent);
-      pyodide.current.FS.writeFile('/user.csv', csvContent);
-
-      pyodide.current.globals.set('drawio_path', '/user.drawio');
-      pyodide.current.globals.set('csv_path', '/user.csv');
-      pyodide.current.globals.set('ontology_iris', ontologyIris);
-
-      pyodide.current.FS.mkdir("/gbad");
-      pyodide.current.FS.mkdir("/gbad/converter");
-      pyodide.current.FS.writeFile("/gbad/converter/preprocessors.py", preprocessorsPy);
-
 
       const pythonCode = `
 import sys
 sys.path.append('/')
-import map_schema
-import draw_io_parser
+import draw_io_parser_simple as parser
 
-#drawio_path = pyodide.globals.get('drawio_path')
-#csv_path = pyodide.globals.get('csv_path')
-#ontology_iris = pyodide.globals.get('ontology_iris')
-
-prefixes = {}
-for line in ontology_iris.split('\\n'):
-    parts = line.split(':')
-    if len(parts) >= 2:
-        prefix = parts[0].strip()
-        iri = ':'.join(parts[1:]).strip()
-        prefixes[prefix] = iri
-
-with open(drawio_path, 'r') as f:
+with open('/user.drawio', 'r') as f:
     drawio_content = f.read()
 
-try:
-    schema_graph = draw_io_parser.parse_drawio_content_to_graph(
-        drawio_content,
-        custom_prefixes=prefixes,
-        metacharacter_substitute=[' =_']
-    )
-
-    rml_content = map_schema.__init__('generic', csv_path, graph_path=schema_graph)
-    rml_content
-except Exception as e:
-    import traceback
-    traceback.format_exc()
+parser.parse_drawio_content_to_graph(drawio_content)
 `;
 
       const result = await pyodide.current.runPythonAsync(pythonCode);
@@ -147,39 +99,6 @@ except Exception as e:
               setDrawioContent(text);
               localStorage.setItem('drawioFileContent', text);
               setSavedMessage(`Draw.io file "${file.name}" saved!`);
-            }}
-          />
-        </label>
-      </div>
-
-      <div style={{ marginTop: '10px' }}>
-        <label>
-          CSV File:
-          <input
-            type="file"
-            accept=".csv"
-            onChange={async (e) => {
-              const file = e.target.files?.[0];
-              if (!file) return;
-              const text = await file.text();
-              setCsvContent(text);
-              localStorage.setItem('csvFileContent', text);
-              setSavedMessage(`CSV file "${file.name}" saved!`);
-            }}
-          />
-        </label>
-      </div>
-
-      <div style={{ marginTop: '10px' }}>
-        <label>
-          Ontology IRIs:
-          <textarea
-            rows={6}
-            style={{ width: '100%', verticalAlign: 'top' }}
-            value={ontologyIris}
-            onChange={(e) => {
-              setOntologyIris(e.target.value);
-              localStorage.setItem('ontologyIris', e.target.value);
             }}
           />
         </label>

--- a/pyodide-react/draw_io_parser_simple.py
+++ b/pyodide-react/draw_io_parser_simple.py
@@ -1,0 +1,19 @@
+from xml.etree.ElementTree import fromstring
+from rdflib import Graph, URIRef, RDF, Namespace
+
+EX = Namespace("http://example.org/")
+
+def parse_drawio_content_to_graph(drawio_content: str) -> str:
+    """Parse minimal .drawio XML and return a Turtle string.
+
+    This simplified parser only creates one triple for each vertex found in the
+    diagram. The triple asserts that the vertex is an ``ex:Node``.
+    """
+    tree = fromstring(drawio_content)
+    graph = Graph()
+    graph.bind("ex", EX)
+    for cell in tree.findall(".//mxCell[@vertex='1']"):
+        node_id = cell.get("id")
+        if node_id:
+            graph.add((URIRef(EX[node_id]), RDF.type, EX.Node))
+    return graph.serialize(format="turtle")

--- a/pyodide-react/run_demo.log
+++ b/pyodide-react/run_demo.log
@@ -258,3 +258,53 @@ verify_conversion.py Bundled page in 150ms: index.html
 End time: Sat Sep 13 13:38:59 UTC 2025
 + echo 'Log file created at /workspace/records_in_contexts_draw_io_parser/pyodide-react/run_demo.log'
 Log file created at /workspace/records_in_contexts_draw_io_parser/pyodide-react/run_demo.log
++ echo '--- System Information ---'
+--- System Information ---
++ uname -a
+Linux d240921e57f6 6.12.13 #1 SMP Thu Mar 13 11:34:50 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
++ echo --------------------------
+--------------------------
++ echo '--- Starting Demo ---'
+--- Starting Demo ---
+++ date
++ echo 'Start time: Sat Sep 13 14:04:34 UTC 2025'
+Start time: Sat Sep 13 14:04:34 UTC 2025
++ cd /workspace/records_in_contexts_draw_io_parser/pyodide-react
++ bun install
+bun install v1.2.14 (6a363a38)
+
++ @types/react@18.3.24
++ @types/react-dom@18.3.7
++ pyodide@0.28.2
++ react@18.3.1
++ react-dom@18.3.1
+
+11 packages installed [588.00ms]
++ SERVER_PID=3928
++ sleep 5
++ bun run index.html
+Bun v1.2.14 dev server ready in 59.72 ms
+
+url: http://localhost:3000/
++ pytest verify_conversion.py
+===================================================== test session starts ======================================================
+platform linux -- Python 3.11.12, pytest-8.4.1, pluggy-1.6.0
+rootdir: /workspace/records_in_contexts_draw_io_parser
+configfile: pyproject.toml
+collected 0 items / 1 error
+
+============================================================ ERRORS ============================================================
+_____________________________________ ERROR collecting pyodide-react/verify_conversion.py ______________________________________
+ImportError while importing test module '/workspace/records_in_contexts_draw_io_parser/pyodide-react/verify_conversion.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+verify_conversion.py:1: in <module>
+    from playwright.sync_api import Page, expect
+E   ModuleNotFoundError: No module named 'playwright'
+=================================================== short test summary info ====================================================
+ERROR verify_conversion.py
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+======================================================= 1 error in 0.24s =======================================================

--- a/report.md
+++ b/report.md
@@ -1,0 +1,21 @@
+# Pyodide React Simplification Report
+
+## Demo script
+
+- Ran `./run_demo.sh` inside `pyodide-react`.
+- Script failed because the Python `playwright` package was missing.
+- Attempted to install requirements via `pip install -r ../next/requirements.dev.txt` and `playwright install && playwright install-deps`.
+- The dependency installation started a large system package install which was interrupted due to resource limits, so the demo could not complete.
+- Existing `run_demo.log` captures the initial attempts and remains in the repository.
+
+## Simplified parser
+
+- Created `pyodide-react/draw_io_parser_simple.py` implementing a minimal parser that reads a `.drawio` XML file, extracts vertex IDs and emits an RDF graph where each vertex is typed as `ex:Node`.
+- Updated `pyodide-react/app.tsx` to load this simplified parser instead of the full conversion pipeline. The React app now uploads only a `.drawio` file and displays the Turtle serialisation returned by the parser.
+
+## Files changed
+
+- `pyodide-react/draw_io_parser_simple.py`
+- `pyodide-react/app.tsx`
+- `pyodide-react/run_demo.log` (generated/updated by demo attempt)
+- `report.md`


### PR DESCRIPTION
## Summary
- add minimal `draw_io_parser_simple.py` that converts drawio vertex IDs into RDF triples
- streamline React app to use simplified parser and only require a draw.io file
- include run_demo.log and report of setup attempt

## Testing
- `pytest` *(fails: ImportError: cannot import name 'serialise' from 'draw_io_parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c579d61420832daf578cc21f140849