### PR TITLE
docs: cross-link tasks with report files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Port the existing four Python scripts (`draw_io_parser.py`, `map_schema.py`, `ma
   - `AICODE-ASK:` question that requires human feedback
 - **Testing scripts**: every task that adds or modifies code must provide a bash script in `scripts/` that runs the relevant tests and writes a log at `logs/<agent>-log-<timestamp>.log` containing start and end timestamps.
 - **Reports**: each agent writes a report to `reports/<agent>-report-<timestamp>.md` summarizing work and any follow‑ups.
+- **Report mapping**: `reports/codex-report-20250913201852.md` links report files to their related tasks.
+- **Globally relevant reports**:
+  - `reports/jules-report-20250913113633.md`
+  - `reports/architect-report-20250913180723.md`
 - **Commit discipline**: one focused task per commit, tests must run before committing, logs and reports included in the commit.
 
 ## Proposed Project Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Each task references the directory where work occurs and the test script to be a
    - Add `package.json` with Volta pin (Node 20), Bun as runtime, scripts (`dev`, `build`, `test`).
    - Add `tsconfig.json`, `.eslintrc`, `.prettierrc` as needed.
    - Test script: `scripts/test-toolchain.sh` runs `bun test` (should exit 0 even when no tests).
+   - Details about how this task description was created are available from report file(s) located at `reports/architect-report-20250913180723.md`.
 2. **P0T2 – Directory scaffolding**
    - Create the `src` subfolders listed above with placeholder index files.
    - Add `tests/setup.ts` if needed for Vitest.
@@ -66,9 +67,10 @@ Each task references the directory where work occurs and the test script to be a
 
 ### Phase 2 – Draw.io Parsing
 1. **P2T1 – Ontology-Agnostic XML Parser** (`src/drawio/parser.ts`) <!-- reviewed -->
-    - **Goal**: To parse the structural and semantic information from a Draw.io XML file into a generic, ontology-agnostic intermediate representation. This module will **not** validate identifiers against any specific ontology. Its sole job is to faithfully translate the diagram's structure.
+   - **Goal**: To parse the structural and semantic information from a Draw.io XML file into a generic, ontology-agnostic intermediate representation. This module will **not** validate identifiers against any specific ontology. Its sole job is to faithfully translate the diagram's structure.
+   - Details about how this task description was created are available from report file(s) located at `reports/jules-report-20250913130525.md`.
 
-    - **AICODE-TODO: P2T1.1 - Define Generic Data Structures** (`src/drawio/model.ts`)
+   - **AICODE-TODO: P2T1.1 - Define Generic Data Structures** (`src/drawio/model.ts`)
         - `DiagramNode`: Represents a swimlane or rounded rectangle.
             - `id`: `string`
             - `value`: `string` (The raw text content, e.g., `rr:template "/KB/{...}"` or `rico:RecordSet`)
@@ -115,6 +117,7 @@ Each task references the directory where work occurs and the test script to be a
 ### Phase 3 – CSV Preprocessing
 1. **P3T1 – Custom preprocessing functions** (`src/csv/preprocess.ts`) <!-- reviewed -->
    - **Goal**: Port the CSV preprocessing logic from `map_schema.py` into a robust, well-tested TypeScript module. This module will accept raw CSV data as an array of objects and return a new array of objects with added and transformed columns. The logic is divided into three distinct pipelines based on a `schema_code`: `add`, `auth`, and `generic`.
+   - Details about how this task description was created are available from report file(s) located at `reports/jules-report-20250913113633.md` and `reports/jules-report-20250913120003.md`.
 
    - **AICODE-TODO: P3T1.1 - Implement a CSV Preprocessing Utility.**
      - Before implementing the specific pipelines, create a utility class or a set of functions in TypeScript that replicates the functionality of the `SourceCSVPreprocessor` class in `gbad/converter/preprocessors.py`.
@@ -186,6 +189,7 @@ Each task references the directory where work occurs and the test script to be a
    - Implement function `mapCsvToRdf(mapping: MappingModel, csv: Record[]): Dataset`.
    - Integrate preprocessing from Phase 3.
    - First round post‑processing hooks (`applyInitialPostprocess(dataset)` in `src/postprocess/initial.ts`).
+   - Details about how this task description was created are available from report file(s) located at `reports/jules-report-20250913121644.md`.
 
 - **AICODE-TODO: P4T2.1 - Implement Basic Mapping Loop and Subject Generation** (`src/mapping/mapper.ts`)
    - **Goal**: Create the `mapCsvToRdf` function skeleton and implement the core iteration logic. This first step will focus on generating the primary resources (subjects) and their `rdf:type` declarations.
@@ -233,6 +237,7 @@ Each task references the directory where work occurs and the test script to be a
 ### Phase 5 – Postprocessing Modules
 1. **P5T1 – Initial postprocessing** (`src/postprocess/initial.ts`) <!-- reviewed -->
    - **Goal**: Port the RDF graph post-processing logic from the Python script `map_rml.py` into a TypeScript module. This module will provide a function `applyInitialPostprocess(dataset)` that takes an `n3.js` dataset and applies a series of transformations to clean up and enrich the data.
+   - Details about how this task description was created are available from report file(s) located at `reports/jules-report-1757793156.md`.
 
    - **AICODE-TODO: P5T1.1 - Implement the `remove_shorter_duplicate_labels` Algorithm.**
      - **Description**: This is the primary active post-processing step. It identifies `rico:RecordSet` resources that have exactly two `rdfs:label` predicates. It then checks if both labels start with the text of the record set's `add:CurrentReferenceCode`. If this condition is met, the algorithm must remove the triple containing the shorter of the two labels.
@@ -296,6 +301,7 @@ Each task references the directory where work occurs and the test script to be a
 ### Phase 6 – Graph Merge & Named Graph Handling
 1. **P6T1 – Merge utility** (`src/merge/merger.ts`) <!-- reviewed -->
    - **Goal**: Create a client-side utility that takes multiple RDF graph datasets (as strings or `n3.Store` objects) and merges them into a single N-Quads string. Each input graph will be placed into its own deterministically generated named graph.
+   - Details about how this task description was created are available from report file(s) located at `reports/jules-report-20250913125101.md`.
    - **AICODE-TODO: P6T1.1 - Implement the Named Graph URI Generation Logic.**
      - Create a function `generateNamedGraphUri(graphContent: string): NamedNode`.
      - This function must replicate the exact logic from `create_named_graph_uri_from_file` in `merge_graphs.py`:

--- a/reports/codex-report-20250913201852.md
+++ b/reports/codex-report-20250913201852.md
@@ -9,15 +9,20 @@
 
 | Report File | Related Task |
 | --- | --- |
-| reports/2025-08-10-jules-generic-schema.md | *(no related task)* |
-| reports/2025-08-10-jules-refactor-drawio-parser.md | *(no related task)* |
-| reports/jules-report-1757793156.md | P5T1 |
-| reports/jules-report-20250913113633.md | P3T1 |
-| reports/jules-report-20250913120003.md | P3T1 |
-| reports/jules-report-20250913121644.md | P4T2 |
-| reports/jules-report-20250913125101.md | P6T1 |
-| reports/jules-report-20250913130525.md | P2T1 |
-| reports/architect-report-20250913180723.md | P0T1 |
+| 2025-08-10-jules-generic-schema.md | *(no related task)* |
+| 2025-08-10-jules-refactor-drawio-parser.md | *(no related task)* |
+| jules-report-1757793156.md | P5T1 |
+| jules-report-20250913120003.md | P3T1 |
+| jules-report-20250913121644.md | P4T2 |
+| jules-report-20250913125101.md | P6T1 |
+| jules-report-20250913130525.md | P2T1 |
+
+## Globally Relevant Reports
+
+These reports capture activities that inform the entire implementation plan rather than a single task:
+
+- jules-report-20250913113633.md
+- architect-report-20250913180723.md
 
 ## Notes
 - The two reports dated 2025-08-10 predate the structured task planning and are unrelated to any `P#T#` entry.

--- a/reports/codex-report-20250913201852.md
+++ b/reports/codex-report-20250913201852.md
@@ -1,0 +1,24 @@
+# Codex Report – 2025-09-13
+
+## Summary
+- Examined commit history for each file in `reports/` to identify related task IDs.
+- Updated `AGENTS.md` tasks to reference their corresponding report files.
+- Compiled mapping between reports and tasks, noting two unrelated older reports.
+
+## Report-to-Task Mapping
+
+| Report File | Related Task |
+| --- | --- |
+| reports/2025-08-10-jules-generic-schema.md | *(no related task)* |
+| reports/2025-08-10-jules-refactor-drawio-parser.md | *(no related task)* |
+| reports/jules-report-1757793156.md | P5T1 |
+| reports/jules-report-20250913113633.md | P3T1 |
+| reports/jules-report-20250913120003.md | P3T1 |
+| reports/jules-report-20250913121644.md | P4T2 |
+| reports/jules-report-20250913125101.md | P6T1 |
+| reports/jules-report-20250913130525.md | P2T1 |
+| reports/architect-report-20250913180723.md | P0T1 |
+
+## Notes
+- The two reports dated 2025-08-10 predate the structured task planning and are unrelated to any `P#T#` entry.
+- Other reports were all produced on 2025-09-13 and map directly to tasks within `AGENTS.md`.


### PR DESCRIPTION
## Summary
- link AGENTS tasks to their corresponding report files
- add codex report mapping every report to its task

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'serialise' from 'draw_io_parser')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0d42e24832da7bdfd4897fd9f66