### PR TITLE
docs: map reports to P1T3 creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Each task references the directory where work occurs and the test script to be a
        - `map_schema.py` – uses `SourceCSVPreprocessor` and `column_split` to showcase transformation needs.
 3. **P1T3 – Prefix Expansion Utility** (`src/lib/prefix.ts`)
     - **Goal**: Create a simple, configurable utility for expanding CURIEs (e.g., `rico:RecordSet`) into full IRIs.
+    - **Details about how this task description was created are available from report file located at [reports/jules-report-20250913130525.md](reports/jules-report-20250913130525.md).**
     - **AICODE-TODO: P1T3.1 - Implement Prefix Map and Expansion Function.**
         - Create a function `createPrefixExpander(prefixMap: Record<string, string>)`. It takes a dictionary mapping prefixes to their IRI bases (e.g., `{ rico: "https://www.ica.org/standards/RiC/ontology#" }`).
         - The function should return another function, `expand(curie: string): string`.

--- a/reports/codex-report-20250914010056.md
+++ b/reports/codex-report-20250914010056.md
@@ -1,0 +1,27 @@
+# Codex Report – 2025-09-14
+
+## Summary
+- Reviewed commit history for each file in `reports/` to identify any mention of P1T3 and whether it described its creation.
+- Updated `AGENTS.md` to link task P1T3 to the report documenting its creation.
+
+## Report-to-P1T3 Mapping
+
+| Report File | Describes P1T3 Creation? |
+| --- | --- |
+| 2025-08-10-jules-generic-schema.md | No |
+| 2025-08-10-jules-refactor-drawio-parser.md | No |
+| architect-report-20250913180723.md | No |
+| codex-report-20250913201852.md | No |
+| codex-report-20250913222101.md | No |
+| jules-report-1757793156.md | No |
+| jules-report-1757793520.md | No |
+| jules-report-20250913113633.md | No |
+| jules-report-20250913120003.md | No |
+| jules-report-20250913121644.md | No |
+| jules-report-20250913125101.md | No |
+| jules-report-20250913130525.md | Yes |
+| jules-report-20250913135639.md | No |
+| jules-report-20250913142338.md | No |
+
+## Notes
+- `jules-report-20250913130525.md` is the only report that documents the creation of task P1T3.


### PR DESCRIPTION
## Summary
- link P1T3 task entry in `AGENTS.md` to the report where it was first created
- catalogue all report files and flag which describes creation of P1T3

## Testing
- `pytest` *(fails: ImportError in test_draw_io_parser.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c61379c5fc832dbaa87722cf46de3b